### PR TITLE
Make it easier to run migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,17 @@ If they do ``terraform apply``
 **Installation And Running**
 ``cd /src/node-api``
 ``npm install``
-Get the DB Creds from another dev, and make a local copy of the DB
+Get the DB Creds from another dev, and make a local copy of the DB. If you have access to the AWS Console you can also get them via SecretsManager
 Copy the ``.env.example`` file to ``.env`` and fill in your local variables
+Modify `config/config.json` so that all placeholders are replaced
 Run ``npm run dev`` and the server should be started
 
 **DB Migrations** 
 - ``npx sequelize-cli migration:generate --name migration-example``
 - Then run ``npm run migration`` and copy the output to the migration file created above
 - Check it over, as that migration generator is still in development
-- When your confident the changes are accurate run ``npx sequelize-cli db:migrate --url={your_db_url}``
+- When your confident the changes are accurate run ``npx sequelize-cli db:migrate``
+- To run the migration in production, run ``NODE_ENV=production npx sequelize-cli db:migrate``
 
 **Deployment**
 ``cd /environments/dev/node-api``

--- a/src/node-api/config/config.json
+++ b/src/node-api/config/config.json
@@ -1,0 +1,38 @@
+{
+  "development": {
+    "username": "postgres",
+    "password": "postgrespass",
+    "database": "elections",
+    "host": "127.0.0.1",
+    "dialect": "postgres"
+  },
+  "local": {
+    "username": "postgres",
+    "password": "postgrespass",
+    "database": "elections",
+    "host": "127.0.0.1",
+    "dialect": "postgres"
+  },
+  "test": {
+    "username": "root",
+    "password": null,
+    "database": "database_test",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
+  },
+  "production": {
+    "username": "postgres",
+    "password": "PASSWORD_GOES_HERE",
+    "database": "elections",
+    "host": "HOST_GOES_HERE",
+    "dialect": "postgres",
+    "port": "PORT_GOES_HERE",
+    "proxy": "PROXY_GOES_HERE",
+    "dialectOptions": {
+      "ssl": {
+        "require": true,
+        "rejectUnauthorized": false
+      }
+    }
+  }
+}

--- a/src/node-api/models/index.js
+++ b/src/node-api/models/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const process = require('process');
+const basename = path.basename(__filename);
+const env = process.env.NODE_ENV || 'development';
+const config = require(__dirname + '/../config/config.json')[env];
+const db = {};
+
+let sequelize;
+if (config.use_env_variable) {
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+} else {
+  sequelize = new Sequelize(config.database, config.username, config.password, config);
+}
+
+fs
+  .readdirSync(__dirname)
+  .filter(file => {
+    return (
+      file.indexOf('.') !== 0 &&
+      file !== basename &&
+      file.slice(-3) === '.js' &&
+      file.indexOf('.test.js') === -1
+    );
+  })
+  .forEach(file => {
+    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+    db[model.name] = model;
+  });
+
+Object.keys(db).forEach(modelName => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;


### PR DESCRIPTION
Add some code & instructions so that you don't need to modify your local sequelize package to run migrations on the production database